### PR TITLE
Play operator refactor

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -475,26 +475,33 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
     bl_category = "Audacity Tools"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        if context.scene.sequence_editor:
+            return True           
+
     def execute(self, context):
-        if not bpy.context.scene.sequence_editor:
-            context.scene.sequence_editor_create()
+        
         scene = context.scene
         sequence = scene.sequence_editor
         screen = context.screen
 
         if not screen.is_animation_playing:
+
             if scene.audacity_mode == "RECORD":
                 bpy.context.scene.use_audio = True
-                do_command("PlayStop:")
+                do_command("PlayLooped:")
                 bpy.ops.screen.animation_play()
+
             if scene.audacity_mode == "SEQUENCE":
                 bpy.context.scene.use_audio = True
                 sound_in = frames_to_sec(scene.frame_current)
                 sound_out = frames_to_sec(scene.frame_end)
                 sound_in = str(sound_in)
                 do_command(("SelectTime:End='"+str(sound_out)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
-                do_command("PlayStop:")
+                do_command("PlayLooped:")
                 bpy.ops.screen.animation_play()
+
             if scene.audacity_mode == "STRIP":
                 strip_name = scene.send_strip
                 if strip_name != "":
@@ -505,8 +512,9 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
                     scene.frame_current = sound_in
                     bpy.context.scene.use_audio = True
                     do_command(("SelectTime:End='"+str(sound_out - 0.1)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
-                    do_command("PlayStop:")
+                    do_command("PlayLooped:")
                     bpy.ops.screen.animation_play()
+                    
         else:
             do_command("PlayStop:")
             bpy.ops.screen.animation_play()
@@ -644,7 +652,7 @@ def register():
 
     for i in classes:
         register_class(i)
-    bpy.types.Scene.send_strip = bpy.props.StringProperty("")
+    bpy.types.Scene.send_strip = bpy.props.StringProperty(name="Audacity send strip")
     bpy.types.Scene.record_start = bpy.props.IntProperty(default=-1)
     bpy.types.Scene.record_start = -1
     bpy.types.Scene.audacity_mode = bpy.props.EnumProperty(

--- a/__init__.py
+++ b/__init__.py
@@ -511,7 +511,7 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         scene = context.scene
-        if scene.sequence_editor:
+        if scene.sequence_editor and scene.audacity_send:
             if not context.screen.is_animation_playing:
                 if scene.audacity_mode == "STRIP" and scene.send_strip == "":
                     return False
@@ -759,6 +759,7 @@ def register():
     for i in classes:
         register_class(i)
     bpy.types.Scene.send_strip = bpy.props.StringProperty("")
+    bpy.types.Scene.audacity_send = bpy.props.BoolProperty()
     bpy.types.Scene.record_start = bpy.props.IntProperty(default=-1)
     bpy.types.Scene.record_start = -1
     bpy.types.Scene.audacity_mode = bpy.props.EnumProperty(
@@ -777,6 +778,7 @@ def unregister():
     for i in classes:
         unregister_class(i)
     del bpy.types.Scene.send_strip
+    del bpy.types.Scene.audacity_send
     del bpy.types.Scene.audacity_mode
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -517,7 +517,7 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
                     
         else:
             do_command("PlayStop:")
-            bpy.ops.screen.animation_play()
+            bpy.ops.screen.animation_cancel(restore_frame = False)
             bpy.ops.anim.previewrange_clear()
             bpy.context.scene.use_audio = False
         return {"FINISHED"}

--- a/__init__.py
+++ b/__init__.py
@@ -359,6 +359,9 @@ class SEQUENCER_OT_send_to_audacity(bpy.types.Operator):
         do_command("FitV:")
         set_volume(strip, True)
 
+        # something went to audacity from this scene
+        scene.audacity_send = True
+
         return {"FINISHED"}
 
 
@@ -438,6 +441,9 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
         do_command("FitInWindow:")
         do_command("FitV:")
 
+        # something went to audacity from this scene
+        scene.audacity_send = True
+
         return {"FINISHED"}
 
 
@@ -463,6 +469,9 @@ class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
 
         do_command("Record1stChoice:")
         bpy.ops.screen.animation_play()
+
+        # something went to audacity from this scene
+        scene.audacity_send = True
 
         return {"FINISHED"}
 

--- a/__init__.py
+++ b/__init__.py
@@ -761,7 +761,7 @@ def register():
     for i in classes:
         register_class(i)
     bpy.types.Scene.send_strip = bpy.props.StringProperty("")
-    bpy.types.Scene.audacity_send = bpy.props.BoolProperty()
+    bpy.types.Scene.audacity_send = bpy.props.BoolProperty(default = False, options = {'SKIP_SAVE'})
     bpy.types.Scene.record_start = bpy.props.IntProperty(default=-1)
     bpy.types.Scene.record_start = -1
     bpy.types.Scene.audacity_mode = bpy.props.EnumProperty(

--- a/__init__.py
+++ b/__init__.py
@@ -652,7 +652,7 @@ def register():
 
     for i in classes:
         register_class(i)
-    bpy.types.Scene.send_strip = bpy.props.StringProperty(name="Audacity send strip")
+    bpy.types.Scene.send_strip = bpy.props.StringProperty("")
     bpy.types.Scene.record_start = bpy.props.IntProperty(default=-1)
     bpy.types.Scene.record_start = -1
     bpy.types.Scene.audacity_mode = bpy.props.EnumProperty(

--- a/__init__.py
+++ b/__init__.py
@@ -487,14 +487,15 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
         screen = context.screen
 
         if not screen.is_animation_playing:
+            
+            # mute blender sound (weird inverted property)
+            context.scene.use_audio = True
 
             if scene.audacity_mode == "RECORD":
-                bpy.context.scene.use_audio = True
                 do_command("PlayLooped:")
                 bpy.ops.screen.animation_play()
 
             if scene.audacity_mode == "SEQUENCE":
-                bpy.context.scene.use_audio = True
                 sound_in = frames_to_sec(scene.frame_current)
                 sound_out = frames_to_sec(scene.frame_end)
                 sound_in = str(sound_in)
@@ -510,7 +511,6 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
                     sound_out = frames_to_sec(sequence.sequences_all[strip_name].frame_duration - sequence.sequences_all[strip_name].frame_offset_end)
                     sound_duration = sequence.sequences_all[strip_name].frame_final_duration
                     scene.frame_current = sound_in
-                    bpy.context.scene.use_audio = True
                     do_command(("SelectTime:End='"+str(sound_out - 0.1)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
                     do_command("PlayLooped:")
                     bpy.ops.screen.animation_play()
@@ -519,7 +519,7 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
             do_command("PlayStop:")
             bpy.ops.screen.animation_cancel(restore_frame = False)
             bpy.ops.anim.previewrange_clear()
-            bpy.context.scene.use_audio = False
+            context.scene.use_audio = False
         return {"FINISHED"}
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,8 @@ import bpy
 import blf
 from time import sleep
 
+from bpy.app.handlers import persistent
+
 from bpy.utils import register_class, unregister_class
 
 from bpy.types import Panel, Menu
@@ -138,6 +140,12 @@ def find_completely_empty_channel():
         empty_channel = channels[-1] + 1
         addSceneChannel = empty_channel
     return addSceneChannel
+
+
+@persistent
+def audacity_tools_startup_handler(scene):
+    for s in bpy.data.scenes:
+        s.audacity_send = False
 
 
 class SEQUENCER_PT_audacity_tools(Panel):
@@ -761,7 +769,7 @@ def register():
     for i in classes:
         register_class(i)
     bpy.types.Scene.send_strip = bpy.props.StringProperty("")
-    bpy.types.Scene.audacity_send = bpy.props.BoolProperty(default = False, options = {'SKIP_SAVE'})
+    bpy.types.Scene.audacity_send = bpy.props.BoolProperty(default = False)
     bpy.types.Scene.record_start = bpy.props.IntProperty(default=-1)
     bpy.types.Scene.record_start = -1
     bpy.types.Scene.audacity_mode = bpy.props.EnumProperty(
@@ -774,6 +782,9 @@ def register():
         ),
     )
 
+    # startup handler
+    bpy.app.handlers.load_post.append(audacity_tools_startup_handler)
+
 
 def unregister():
 
@@ -783,6 +794,8 @@ def unregister():
     del bpy.types.Scene.audacity_send
     del bpy.types.Scene.audacity_mode
 
+    # startup handler
+    bpy.app.handlers.load_post.remove(audacity_tools_startup_handler)
 
 if __name__ == "__main__":
     register()

--- a/__init__.py
+++ b/__init__.py
@@ -169,14 +169,7 @@ class SEQUENCER_PT_audacity_tools(Panel):
             )
             col.separator()
             row = col.row(align=True)
-            if not screen.is_animation_playing:
-                row.operator(
-                    "sequencer.play_stop_in_audacity", text="Play", icon="PLAY"
-                )
-            else:
-                row.operator(
-                    "sequencer.play_stop_in_audacity", text="Stop", icon="SNAP_FACE"
-                )
+            row.operator("sequencer.play_stop_in_audacity", text="Play", icon="PLAY")
             if scene.use_audio:
                 row.prop(scene, "use_audio", text="",icon="PLAY_SOUND", emboss = False)
             else:
@@ -546,7 +539,7 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
         return {'RUNNING_MODAL'}
 
     def invoke(self, context, event):
-        if not context.area.type == 'VIEW_3D':
+        if not context.area.type == 'SEQUENCE_EDITOR':
             self.report({'WARNING'}, "Sequence Editor Space not found, cannot run operator")
             return {'CANCELLED'}
 

--- a/__init__.py
+++ b/__init__.py
@@ -170,11 +170,11 @@ class SEQUENCER_PT_audacity_tools(Panel):
             row = col.row(align=True)
             if not screen.is_animation_playing:
                 row.operator(
-                    "sequencer.stop_in_audacity", text="Play", icon="PLAY"
+                    "sequencer.play_stop_in_audacity", text="Play", icon="PLAY"
                 )
             else:
                 row.operator(
-                    "sequencer.stop_in_audacity", text="Stop", icon="SNAP_FACE"
+                    "sequencer.play_stop_in_audacity", text="Stop", icon="SNAP_FACE"
                 )
             if scene.use_audio:
                 row.prop(scene, "use_audio", text="",icon="PLAY_SOUND", emboss = False)
@@ -194,11 +194,11 @@ class SEQUENCER_PT_audacity_tools(Panel):
             row = col.row(align=True)
             if not screen.is_animation_playing:
                 row.operator(
-                    "sequencer.stop_in_audacity", text="Play", icon="PLAY"
+                    "sequencer.play_stop_in_audacity", text="Play", icon="PLAY"
                 )
             else:
                 row.operator(
-                    "sequencer.stop_in_audacity", text="Stop", icon="SNAP_FACE"
+                    "sequencer.play_stop_in_audacity", text="Stop", icon="SNAP_FACE"
                 )
             if scene.use_audio:
                 row.prop(scene, "use_audio", text="",icon="PLAY_SOUND", emboss = False)
@@ -212,7 +212,7 @@ class SEQUENCER_PT_audacity_tools(Panel):
                 )
             elif bpy.types.Scene.record_start != -1:
                 col.operator(
-                    "sequencer.stop_in_audacity", text="Stop", icon="SNAP_FACE"
+                    "sequencer.play_stop_in_audacity", text="Stop", icon="SNAP_FACE"
                 )
             sub = col.column()
             sub.active = not bpy.types.Scene.record_start == -1
@@ -466,12 +466,12 @@ class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class SEQUENCER_OT_stop_in_audacity(bpy.types.Operator):
-    """Stop Audacity"""
+class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
+    """Play/Stop Audacity"""
 
-    bl_idname = "sequencer.stop_in_audacity"
+    bl_idname = "sequencer.play_stop_in_audacity"
     bl_label = "Play/Stop"
-    bl_description = "Stop in Audacity"
+    bl_description = "Play/Stop in Audacity"
     bl_category = "Audacity Tools"
     bl_options = {"REGISTER", "UNDO"}
 
@@ -635,7 +635,7 @@ classes = (
     SEQUENCER_OT_send_project_to_audacity,
     SEQUENCER_OT_receive_from_audacity,
     SEQUENCER_PT_audacity_tools,
-    SEQUENCER_OT_stop_in_audacity,
+    SEQUENCER_OT_play_stop_in_audacity,
     SEQUENCER_OT_record_in_audacity,
 )
 

--- a/__init__.py
+++ b/__init__.py
@@ -473,7 +473,7 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
     bl_label = "Play/Stop"
     bl_description = "Play/Stop in Audacity"
     bl_category = "Audacity Tools"
-    bl_options = {"REGISTER", "UNDO"}
+    bl_options = {"REGISTER"}
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
A try to make the play operator more consistent and predictable, here is a little demo video :
https://youtu.be/e3l50GfcjGQ

There are a few changes in the behavior 
- The play operator has a poll to not be able to work if animation is playing, if audacity has not received anything yet during this session and from this scene, if in strip mode with no strip name in send_strip property
- The play operator is now modal, so the operator will work until Space/Esc is pressed, or animation is stopped. The mouse actions are still possible ("PASSTHROUGH") to navigate in blender
- The operator can be either cancel (ESC or animation stopped) or finish (SPACE), if cancelled, the playhead will be reset to original location, if finished, the playhead will stay in current location
- Send operators now set the audacity_send property to True to be able to track if something has been sent to Audacity during this session
- The modal draw on sequence editor a "report" for the user to have feedback operator is working and hints on shortcuts
- When playing in sequence mode, the play starts from the begining of the active frame range (normal or preview) and read the entire range
- the play command sent to audacity is now "PlayLooped:" to mimic blender behavior and stays synced with it
- [edit] remove undo of this operator, seems weird for a play operator to have undo ability, i think it could be confusing for user to have this undo step instead of, for example, their last cut in the edit
- [edit] added a startup handler to reset the audacity_send properties of every scenes when loading a blend

I hope you will find these tweaks coherent, of course tell me if anything bothers you ! cheers !