### PR TITLE
Pipe improvement

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,6 +49,7 @@ from .operators import (
     record_in_audacity,
     send_project_to_audacity,
     send_strip_to_audacity,
+    refresh_pipe,
 )
 
 
@@ -68,6 +69,7 @@ def register():
     record_in_audacity.register()
     send_project_to_audacity.register()
     send_strip_to_audacity.register()
+    refresh_pipe.register()
 
 
 def unregister():
@@ -82,3 +84,4 @@ def unregister():
     record_in_audacity.unregister()
     send_project_to_audacity.unregister()
     send_strip_to_audacity.unregister()
+    refresh_pipe.unregister()

--- a/addon_prefs.py
+++ b/addon_prefs.py
@@ -7,9 +7,26 @@ addon_name = os.path.basename(os.path.dirname(__file__))
 class AUDACITYTOOLS_PF_Addon_Prefs(bpy.types.AddonPreferences):
     bl_idname = addon_name
 
+    audacity_executable : bpy.props.StringProperty(
+        name = "Audacity executable",
+        subtype = "FILE_PATH",
+        )
+
+    audacity_waiting_time : bpy.props.FloatProperty(
+        name = "Audacity waiting time",
+        description = "Waiting time in seconds for Audacity opening",
+        default = 5.0,
+        precision = 1,
+        min = 2.0,
+        max = 20.0,
+    )
+
 
     def draw(self, context):
         layout = self.layout
+
+        layout.prop(self, "audacity_executable")
+        layout.prop(self, "audacity_waiting_time")
  
 
 # get addon preferences

--- a/addon_prefs.py
+++ b/addon_prefs.py
@@ -15,10 +15,10 @@ class AUDACITYTOOLS_PF_Addon_Prefs(bpy.types.AddonPreferences):
     audacity_waiting_time : bpy.props.FloatProperty(
         name = "Audacity waiting time",
         description = "Waiting time in seconds for Audacity opening",
-        default = 5.0,
+        default = 0.5,
         precision = 1,
-        min = 2.0,
-        max = 20.0,
+        min = 0.3,
+        max = 10.0,
     )
 
 

--- a/gui.py
+++ b/gui.py
@@ -23,11 +23,13 @@ class SEQUENCER_PT_audacity_tools(bpy.types.Panel):
 
         # pipe infos
         pipe = context.window_manager.audacity_tools_pipe_available
+        row = layout.row(align=True)
         if pipe:
-            layout.label(text = "Pipe available", icon = "CHECKMARK")
+            row.label(text = "Pipe available", icon = "CHECKMARK")
         else:
-            layout.label(text = "Pipe unavailable", icon = "ERROR")
-
+            row.label(text = "Pipe unavailable", icon = "ERROR")
+        
+        row.operator("sequencer.refresh_audacity_pipe", text = "", icon = "FILE_REFRESH")
 
         layout.prop(props, "audacity_mode", text="")
         col = layout.column(align=(False))

--- a/gui.py
+++ b/gui.py
@@ -23,7 +23,9 @@ class SEQUENCER_PT_audacity_tools(bpy.types.Panel):
 
         # pipe infos
         pipe = context.window_manager.audacity_tools_pipe_available
-        row = layout.row(align=True)
+
+        box = layout.box()
+        row = box.row(align=True)
         if pipe:
             row.label(text = "Pipe available", icon = "CHECKMARK")
         else:

--- a/gui.py
+++ b/gui.py
@@ -21,6 +21,14 @@ class SEQUENCER_PT_audacity_tools(bpy.types.Panel):
         screen = context.screen
         layout = self.layout
 
+        # pipe infos
+        pipe = context.window_manager.audacity_tools_pipe_available
+        if pipe:
+            layout.label(text = "Pipe available", icon = "CHECKMARK")
+        else:
+            layout.label(text = "Pipe unavailable", icon = "ERROR")
+
+
         layout.prop(props, "audacity_mode", text="")
         col = layout.column(align=(False))
 

--- a/operators/play_stop_in_audacity.py
+++ b/operators/play_stop_in_audacity.py
@@ -2,7 +2,7 @@ import bpy
 
 from .send_strip_to_audacity import frames_to_sec
 
-from ..pipe_utilities import do_command
+from .. import pipe_utilities
 
 
 class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
@@ -15,6 +15,11 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
+        # check if pipe available
+        if not pipe_utilities.check_pipe(False):
+            self.report({"WARNING"}, "No pipe available")
+            return {"FINISHED"}
+
         if not bpy.context.scene.sequence_editor:
             context.scene.sequence_editor_create()
         scene = context.scene
@@ -25,15 +30,15 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
         if not screen.is_animation_playing:
             if props.audacity_mode == "RECORD":
                 bpy.context.scene.use_audio = True
-                do_command("PlayStop:")
+                pipe_utilities.do_command("PlayStop:")
                 bpy.ops.screen.animation_play()
             elif props.audacity_mode == "SEQUENCE":
                 bpy.context.scene.use_audio = True
                 sound_in = frames_to_sec(scene.frame_current)
                 sound_out = frames_to_sec(scene.frame_end)
                 sound_in = str(sound_in)
-                do_command(("SelectTime:End='"+str(sound_out)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
-                do_command("PlayStop:")
+                pipe_utilities.do_command(("SelectTime:End='"+str(sound_out)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
+                pipe_utilities.do_command("PlayStop:")
                 bpy.ops.screen.animation_play()
             elif props.audacity_mode == "STRIP":
                 strip_name = props.send_strip
@@ -44,11 +49,11 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
                     sound_duration = sequence.sequences_all[strip_name].frame_final_duration
                     scene.frame_current = sound_in
                     bpy.context.scene.use_audio = True
-                    do_command(("SelectTime:End='"+str(sound_out - 0.1)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
-                    do_command("PlayStop:")
+                    pipe_utilities.do_command(("SelectTime:End='"+str(sound_out - 0.1)+"' RelativeTo='ProjectStart' Start='"+str(sound_in)+"'").replace("'", '"'))
+                    pipe_utilities.do_command("PlayStop:")
                     bpy.ops.screen.animation_play()
         else:
-            do_command("PlayStop:")
+            pipe_utilities.do_command("PlayStop:")
             bpy.ops.screen.animation_play()
             bpy.ops.anim.previewrange_clear()
             bpy.context.scene.use_audio = False

--- a/operators/play_stop_in_audacity.py
+++ b/operators/play_stop_in_audacity.py
@@ -14,12 +14,16 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
     bl_category = "Audacity Tools"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return context.window_manager.audacity_tools_pipe_available
+
     def execute(self, context):
         # check if pipe available
-        if not pipe_utilities.check_pipe(False):
+        if not pipe_utilities.check_pipe():
             self.report({"WARNING"}, "No pipe available")
             return {"FINISHED"}
-
+            
         if not bpy.context.scene.sequence_editor:
             context.scene.sequence_editor_create()
         scene = context.scene

--- a/operators/play_stop_in_audacity.py
+++ b/operators/play_stop_in_audacity.py
@@ -21,9 +21,9 @@ class SEQUENCER_OT_play_stop_in_audacity(bpy.types.Operator):
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():
-            self.report({"WARNING"}, "No pipe available")
+            self.report({"WARNING"}, "No pipe available, try refresh operator")
             return {"FINISHED"}
-            
+
         if not bpy.context.scene.sequence_editor:
             context.scene.sequence_editor_create()
         scene = context.scene

--- a/operators/receive_from_audacity.py
+++ b/operators/receive_from_audacity.py
@@ -2,7 +2,7 @@ import bpy, os, time
 
 from bpy_extras.io_utils import ExportHelper
 
-from ..pipe_utilities import do_command
+from .. import pipe_utilities
 
 
 # get unique name
@@ -64,26 +64,31 @@ class SEQUENCER_OT_receive_from_audacity(bpy.types.Operator, ExportHelper):
                 self.filepath = base_path
 
     def execute(self, context):
+        # check if pipe available
+        if not pipe_utilities.check_pipe(False):
+            self.report({"WARNING"}, "No pipe available")
+            return {"FINISHED"}
+
         filepath = self.filepath
         scene = context.scene
         props = scene.audacity_tools_props
         mode = props.audacity_mode
 
         if mode == "SEQUENCE":
-            do_command("NewStereoTrack")
-            do_command(
+            pipe_utilities.do_command("NewStereoTrack")
+            pipe_utilities.do_command(
                 ("SelectTime:End='1' RelativeTo='ProjectStart' Start='0'").replace(
                     "'", '"'
                 )
             )
-            do_command("Silence:Duration='1'").replace("'", '"')
-            do_command("MixAndRender")
-        do_command("SelAllTracks")
-        do_command("SelTrackStartToEnd")
-        do_command(f"Export2: Filename={filepath} NumChannels=2")
+            pipe_utilities.do_command("Silence:Duration='1'").replace("'", '"')
+            pipe_utilities.do_command("MixAndRender")
+        pipe_utilities.do_command("SelAllTracks")
+        pipe_utilities.do_command("SelTrackStartToEnd")
+        pipe_utilities.do_command(f"Export2: Filename={filepath} NumChannels=2")
         if mode == "SEQUENCE":
-            do_command("Undo")
-            do_command("Undo")
+            pipe_utilities.do_command("Undo")
+            pipe_utilities.do_command("Undo")
         time.sleep(0.1)
 
         sequence = scene.sequence_editor

--- a/operators/receive_from_audacity.py
+++ b/operators/receive_from_audacity.py
@@ -70,7 +70,7 @@ class SEQUENCER_OT_receive_from_audacity(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe(False):
-            self.report({"WARNING"}, "No pipe available")
+            self.report({"WARNING"}, "No pipe available, try refresh operator")
             return {"FINISHED"}
 
         filepath = self.filepath

--- a/operators/receive_from_audacity.py
+++ b/operators/receive_from_audacity.py
@@ -51,6 +51,10 @@ class SEQUENCER_OT_receive_from_audacity(bpy.types.Operator, ExportHelper):
         maxlen=255,
     )
 
+    @classmethod
+    def poll(cls, context):
+        return context.window_manager.audacity_tools_pipe_available
+
     def __init__(self):
         # if file saved, get proper unique name
         if bpy.data.filepath:

--- a/operators/record_in_audacity.py
+++ b/operators/record_in_audacity.py
@@ -19,7 +19,7 @@ class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():
-            self.report({"WARNING"}, "No pipe available")
+            self.report({"WARNING"}, "No pipe available, try refresh operator")
             return {"FINISHED"}
 
         if not bpy.context.scene.sequence_editor:

--- a/operators/record_in_audacity.py
+++ b/operators/record_in_audacity.py
@@ -1,6 +1,6 @@
 import bpy
 
-from ..pipe_utilities import do_command
+from .. import pipe_utilities
 
 
 class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
@@ -13,6 +13,10 @@ class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
+        # check if pipe available
+        if not pipe_utilities.check_pipe():
+            self.report({"WARNING"}, "No pipe available")
+            return {"FINISHED"}
 
         if not bpy.context.scene.sequence_editor:
             bpy.context.scene.sequence_editor_create()
@@ -23,10 +27,10 @@ class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
         props.record_start = scene.frame_current
         bpy.context.scene.use_audio = True
 
-        do_command("SelectAll")
-        do_command("RemoveTracks")
+        pipe_utilities.do_command("SelectAll")
+        pipe_utilities.do_command("RemoveTracks")
 
-        do_command("Record1stChoice:")
+        pipe_utilities.do_command("Record1stChoice:")
         bpy.ops.screen.animation_play()
 
         return {"FINISHED"}

--- a/operators/record_in_audacity.py
+++ b/operators/record_in_audacity.py
@@ -12,6 +12,10 @@ class SEQUENCER_OT_record_in_audacity(bpy.types.Operator):
     bl_category = "Audacity Tools"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return context.window_manager.audacity_tools_pipe_available
+
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():

--- a/operators/refresh_pipe.py
+++ b/operators/refresh_pipe.py
@@ -1,0 +1,28 @@
+import bpy
+
+from .. import pipe_utilities
+
+
+class SEQUENCER_OT_refresh_audacity_pipe(bpy.types.Operator):
+    """Record Audacity"""
+
+    bl_idname = "sequencer.refresh_audacity_pipe"
+    bl_label = "Refresh Pipe"
+    bl_description = "Refresh the Audacity pipe"
+    bl_category = "Audacity Tools"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context):
+        # check if pipe available
+        pipe_utilities.check_pipe()
+
+        return {"FINISHED"}
+
+
+### REGISTER ---
+
+def register():
+    bpy.utils.register_class(SEQUENCER_OT_refresh_audacity_pipe)
+
+def unregister():
+    bpy.utils.unregister_class(SEQUENCER_OT_refresh_audacity_pipe)

--- a/operators/refresh_pipe.py
+++ b/operators/refresh_pipe.py
@@ -14,7 +14,7 @@ class SEQUENCER_OT_refresh_audacity_pipe(bpy.types.Operator):
 
     def execute(self, context):
         # check if pipe available
-        pipe_utilities.check_pipe()
+        pipe_utilities.check_set_pipe()
 
         return {"FINISHED"}
 

--- a/operators/refresh_pipe.py
+++ b/operators/refresh_pipe.py
@@ -15,7 +15,7 @@ class SEQUENCER_OT_refresh_audacity_pipe(bpy.types.Operator):
     def execute(self, context):
         # check if pipe available
         if pipe_utilities.check_set_pipe():
-            self.report({"WARNING"}, "Pipe set")
+            self.report({"INFO"}, "Pipe set")
         else:
             self.report({"WARNING"}, "No pipe available")
 

--- a/operators/refresh_pipe.py
+++ b/operators/refresh_pipe.py
@@ -14,7 +14,10 @@ class SEQUENCER_OT_refresh_audacity_pipe(bpy.types.Operator):
 
     def execute(self, context):
         # check if pipe available
-        pipe_utilities.check_set_pipe()
+        if pipe_utilities.check_set_pipe():
+            self.report({"WARNING"}, "Pipe set")
+        else:
+            self.report({"WARNING"}, "No pipe available")
 
         return {"FINISHED"}
 

--- a/operators/send_project_to_audacity.py
+++ b/operators/send_project_to_audacity.py
@@ -44,6 +44,10 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
     bl_category = "Audacity Tools"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return context.window_manager.audacity_tools_pipe_available
+
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():

--- a/operators/send_project_to_audacity.py
+++ b/operators/send_project_to_audacity.py
@@ -51,7 +51,7 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():
-            self.report({"WARNING"}, "No pipe available")
+            self.report({"WARNING"}, "No pipe available, try refresh operator")
             return {"FINISHED"}
 
         if not bpy.context.scene.sequence_editor:

--- a/operators/send_project_to_audacity.py
+++ b/operators/send_project_to_audacity.py
@@ -1,7 +1,7 @@
 import bpy
 
 from . import send_strip_to_audacity
-from ..pipe_utilities import do_command
+from .. import pipe_utilities
 
 
 # return sound sequences of timeline
@@ -45,6 +45,11 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
+        # check if pipe available
+        if not pipe_utilities.check_pipe():
+            self.report({"WARNING"}, "No pipe available")
+            return {"FINISHED"}
+
         if not bpy.context.scene.sequence_editor:
             bpy.context.scene.sequence_editor_create()
         strip = send_strip_to_audacity.act_strip(context)
@@ -55,8 +60,8 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
         fps = round((render.fps / render.fps_base), 3)
         props.record_start = -1
 
-        do_command("SelectAll")
-        do_command("RemoveTracks")
+        pipe_utilities.do_command("SelectAll")
+        pipe_utilities.do_command("RemoveTracks")
 
         sequences = collect_files()
         tracks = get_tracks(sequences)
@@ -65,7 +70,7 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
 
         for track in reversed(tracks):
             track_index = track_index + 1
-            do_command("NewStereoTrack:")
+            pipe_utilities.do_command("NewStereoTrack:")
 
             for sequence_data in track:
                 index = index + 1
@@ -81,9 +86,9 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
                         chr(34) + bpy.path.abspath(sequence.sound.filepath) + chr(34)
                     )
                     stream_start = send_strip_to_audacity.frames_to_sec(sequence.frame_offset_start)
-                    do_command(f"Import2: Filename={filename}")
+                    pipe_utilities.do_command(f"Import2: Filename={filename}")
                     # Remove unused material.
-                    do_command(
+                    pipe_utilities.do_command(
                         (
                             "SelectTime:End='"
                             + str(length - sound_offset_out)
@@ -92,12 +97,12 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
                             + "'"
                         ).replace("'", '"')
                     )
-                    do_command("Trim:")
+                    pipe_utilities.do_command("Trim:")
                     # Cut & paste into correct track and remove the old.
-                    do_command("Cut:")
-                    do_command("RemoveTracks:")
-                    do_command("SelectTracks:Track=" + str(track_index))
-                    do_command(
+                    pipe_utilities.do_command("Cut:")
+                    pipe_utilities.do_command("RemoveTracks:")
+                    pipe_utilities.do_command("SelectTracks:Track=" + str(track_index))
+                    pipe_utilities.do_command(
                         (
                             "SelectTime:End='"
                             + str(sound_out)
@@ -106,11 +111,11 @@ class SEQUENCER_OT_send_project_to_audacity(bpy.types.Operator):
                             + "'"
                         ).replace("'", '"')
                     )
-                    do_command("Paste:")
+                    pipe_utilities.do_command("Paste:")
                     send_strip_to_audacity.set_volume(sequence, False)
-        do_command("ZoomSel:")
-        do_command("FitInWindow:")
-        do_command("FitV:")
+        pipe_utilities.do_command("ZoomSel:")
+        pipe_utilities.do_command("FitInWindow:")
+        pipe_utilities.do_command("FitV:")
 
         return {"FINISHED"}
 

--- a/operators/send_strip_to_audacity.py
+++ b/operators/send_strip_to_audacity.py
@@ -110,6 +110,10 @@ class SEQUENCER_OT_send_strip_to_audacity(bpy.types.Operator):
     bl_category = "Audacity Tools"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return context.window_manager.audacity_tools_pipe_available
+
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():

--- a/operators/send_strip_to_audacity.py
+++ b/operators/send_strip_to_audacity.py
@@ -1,6 +1,6 @@
 import bpy
 
-from ..pipe_utilities import do_command
+from .. import pipe_utilities
 
 
 # return active strip
@@ -70,14 +70,14 @@ def set_volume(strip, active):
                             else:
                                 frame = f.co[0]
                             if active:
-                                do_command(
+                                pipe_utilities.do_command(
                                     "SetEnvelope: Time="
                                     + str(frames_to_sec(frame - sound_start))
                                     + " Value="
                                     + str(volume)
                                 )
                             else:
-                                do_command(
+                                pipe_utilities.do_command(
                                     "SetEnvelope: Time="
                                     + str(frames_to_sec(frame))
                                     + " Value="
@@ -86,14 +86,14 @@ def set_volume(strip, active):
 
     if fade_curve is None and volume != 1:
         if mode == "STRIP":
-            do_command(
+            pipe_utilities.do_command(
                 "SetEnvelope: Time="
                 + str(frames_to_sec(name.frame_offset_start + 2))
                 + " Value="
                 + str(volume)
             )
         if mode == "SEQUENCE":
-            do_command(
+            pipe_utilities.do_command(
                 "SetEnvelope: Time="
                 + str(frames_to_sec(name.frame_final_start + 2))
                 + " Value="
@@ -111,6 +111,11 @@ class SEQUENCER_OT_send_strip_to_audacity(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
+        # check if pipe available
+        if not pipe_utilities.check_pipe():
+            self.report({"WARNING"}, "No pipe available")
+            return {"FINISHED"}
+
         if not bpy.context.scene.sequence_editor:
             bpy.context.scene.sequence_editor_create()
         strip = act_strip(context)
@@ -136,11 +141,11 @@ class SEQUENCER_OT_send_strip_to_audacity(bpy.types.Operator):
         sound_in = str(sound_in)
 
         # Import.
-        do_command("SelectAll")
-        do_command("RemoveTracks")
-        do_command(f"Import2: Filename={filename}")
+        pipe_utilities.do_command("SelectAll")
+        pipe_utilities.do_command("RemoveTracks")
+        pipe_utilities.do_command(f"Import2: Filename={filename}")
         # Label.
-        do_command(
+        pipe_utilities.do_command(
             (
                 "SelectTime:End='"
                 + sound_out
@@ -149,12 +154,12 @@ class SEQUENCER_OT_send_strip_to_audacity(bpy.types.Operator):
                 + "'"
             ).replace("'", '"')
         )
-        do_command("AddLabel:")
-        do_command(("SetLabel:Label='0' Text='Used in Blender'").replace("'", '"'))
+        pipe_utilities.do_command("AddLabel:")
+        pipe_utilities.do_command(("SetLabel:Label='0' Text='Used in Blender'").replace("'", '"'))
         # View.
-        do_command("ZoomSel:")
-        do_command("FitInWindow:")
-        do_command("FitV:")
+        pipe_utilities.do_command("ZoomSel:")
+        pipe_utilities.do_command("FitInWindow:")
+        pipe_utilities.do_command("FitV:")
         set_volume(strip, True)
 
         return {"FINISHED"}

--- a/operators/send_strip_to_audacity.py
+++ b/operators/send_strip_to_audacity.py
@@ -117,7 +117,7 @@ class SEQUENCER_OT_send_strip_to_audacity(bpy.types.Operator):
     def execute(self, context):
         # check if pipe available
         if not pipe_utilities.check_pipe():
-            self.report({"WARNING"}, "No pipe available")
+            self.report({"WARNING"}, "No pipe available, try refresh operator")
             return {"FINISHED"}
 
         if not bpy.context.scene.sequence_editor:

--- a/pipe_utilities.py
+++ b/pipe_utilities.py
@@ -1,25 +1,78 @@
 import sys, time, os
 
+from .addon_prefs import get_addon_preferences
 
-# Platform specific constants
-if sys.platform == "win32":
-    PIPE_TO_AUDACITY = "\\\\.\\pipe\\ToSrvPipe"
-    PIPE_FROM_AUDACITY = "\\\\.\\pipe\\FromSrvPipe"
-    EOL = "\r\n\0"
-else:
-    PIPE_TO_AUDACITY = "/tmp/audacity_script_pipe.to." + str(os.getuid())
-    PIPE_FROM_AUDACITY = "/tmp/audacity_script_pipe.from." + str(os.getuid())
-    EOL = "\n"
-try:
-    time.sleep(0.01)
-    TOPIPE = open(PIPE_TO_AUDACITY, "w")
-    print("Audacity Tools --- File to write to has been opened")
-    FROMPIPE = open(PIPE_FROM_AUDACITY, "r")
-    print("Audacity Tools --- File to read from has now been opened too\r\n")
-except:
-    print(
-        "Audacity Tools --- Unable to run. Ensure Audacity is running with mod-script-pipe. Or try to restart Blender."
-    )
+
+def return_audacity_pipe():
+    TOPIPE = None
+    FROMPIPE = None
+    EOL = None
+    # Platform specific constants
+    if sys.platform == "win32":
+        PIPE_TO_AUDACITY = "\\\\.\\pipe\\ToSrvPipe"
+        PIPE_FROM_AUDACITY = "\\\\.\\pipe\\FromSrvPipe"
+        EOL = "\r\n\0"
+    else:
+        PIPE_TO_AUDACITY = "/tmp/audacity_script_pipe.to." + str(os.getuid())
+        PIPE_FROM_AUDACITY = "/tmp/audacity_script_pipe.from." + str(os.getuid())
+        EOL = "\n"
+    try:
+        time.sleep(0.01)
+        TOPIPE = open(PIPE_TO_AUDACITY, "w")
+        print("Audacity Tools --- File to write to has been opened")
+        FROMPIPE = open(PIPE_FROM_AUDACITY, "r")
+        print("Audacity Tools --- File to read from has now been opened too\r\n")
+    except:
+        print(
+            "Audacity Tools --- Unable to run. Ensure Audacity is running with mod-script-pipe. Or try to restart Blender."
+        )
+    
+    return TOPIPE, FROMPIPE, EOL
+
+
+TOPIPE, FROMPIPE, EOL = return_audacity_pipe()
+
+
+def check_pipe():
+    global TOPIPE
+    global FROMPIPE
+    global EOL
+
+    if TOPIPE is not None:
+        try:
+            TOPIPE.write("ToggleScrubRuler:" + EOL)
+            TOPIPE.write("ToggleScrubRuler:" + EOL)
+            TOPIPE.flush()
+            return True
+        except OSError:
+            pass
+
+    _to, _from, _eol = return_audacity_pipe()
+    if _to is not None:
+        TOPIPE = _to
+        FROMPIPE = _from
+        EOL = _eol
+        return True
+
+    elif launch_audacity():
+        time.sleep(get_addon_preferences().audacity_waiting_time)
+        _to, _from, _eol = return_audacity_pipe()
+        if _to is not None:
+            TOPIPE = _to
+            FROMPIPE = _from
+            EOL = _eol
+            return True
+            
+    return False
+
+
+def launch_audacity():
+    app_path = get_addon_preferences().audacity_executable
+    if os.path.isfile(app_path):
+        os.startfile(app_path)
+        return True
+    else:
+        return False
 
 
 def send_command(command):
@@ -36,7 +89,7 @@ def get_response():
     while True:
         result += line
         line = FROMPIPE.readline()
-        print(f"Line read: [{line}]")
+        #print(f"Line read: [{line}]")
         if line == "\n":
             return result
 

--- a/pipe_utilities.py
+++ b/pipe_utilities.py
@@ -31,7 +31,7 @@ def return_audacity_pipe():
     return TOPIPE, FROMPIPE, EOL
 
 
-def check_pipe(launch=True):
+def check_set_pipe(launch=True):
     print("Audacity Tools --- Looking for Audacity pipe")
 
     winman = bpy.data.window_managers[0]
@@ -71,6 +71,21 @@ def check_pipe(launch=True):
                 return True
 
     winman.audacity_tools_pipe_available = False
+    return False
+
+
+def check_pipe():
+    winman = bpy.data.window_managers[0]
+    if TOPIPE is not None:
+        try:
+            TOPIPE.write("ToggleScrubRuler:" + EOL)
+            TOPIPE.write("ToggleScrubRuler:" + EOL)
+            TOPIPE.flush()
+            winman.audacity_tools_pipe_available = True
+            return True
+        except OSError:
+            pass
+    winman.audacity_tools_pipe_available = False   
     return False
 
 

--- a/pipe_utilities.py
+++ b/pipe_utilities.py
@@ -1,12 +1,14 @@
-import sys, time, os
+import bpy, sys, time, os
 
 from .addon_prefs import get_addon_preferences
 
 
+TOPIPE = FROMPIPE = EOL = None
+
 def return_audacity_pipe():
     TOPIPE = None
     FROMPIPE = None
-    EOL = None
+    EOL = None       
     # Platform specific constants
     if sys.platform == "win32":
         PIPE_TO_AUDACITY = "\\\\.\\pipe\\ToSrvPipe"
@@ -29,11 +31,10 @@ def return_audacity_pipe():
     return TOPIPE, FROMPIPE, EOL
 
 
-TOPIPE, FROMPIPE, EOL = return_audacity_pipe()
-
-
 def check_pipe(launch=True):
     print("Audacity Tools --- Looking for Audacity pipe")
+
+    winman = bpy.data.window_managers[0]
 
     global TOPIPE
     global FROMPIPE
@@ -44,6 +45,7 @@ def check_pipe(launch=True):
             TOPIPE.write("ToggleScrubRuler:" + EOL)
             TOPIPE.write("ToggleScrubRuler:" + EOL)
             TOPIPE.flush()
+            winman.audacity_tools_pipe_available = True
             return True
         except OSError:
             pass
@@ -53,6 +55,7 @@ def check_pipe(launch=True):
         TOPIPE = _to
         FROMPIPE = _from
         EOL = _eol
+        winman.audacity_tools_pipe_available = True
         return True
 
     elif launch:
@@ -64,8 +67,10 @@ def check_pipe(launch=True):
                 TOPIPE = _to
                 FROMPIPE = _from
                 EOL = _eol
+                winman.audacity_tools_pipe_available = True
                 return True
 
+    winman.audacity_tools_pipe_available = False
     return False
 
 

--- a/pipe_utilities.py
+++ b/pipe_utilities.py
@@ -19,13 +19,12 @@ def return_audacity_pipe():
     try:
         time.sleep(0.01)
         TOPIPE = open(PIPE_TO_AUDACITY, "w")
-        print("Audacity Tools --- File to write to has been opened")
+        # print("Audacity Tools --- File to write to has been opened")
         FROMPIPE = open(PIPE_FROM_AUDACITY, "r")
-        print("Audacity Tools --- File to read from has now been opened too\r\n")
+        # print("Audacity Tools --- File to read from has now been opened too\r\n")
     except:
-        print(
-            "Audacity Tools --- Unable to run. Ensure Audacity is running with mod-script-pipe. Or try to restart Blender."
-        )
+        pass
+        # print("Audacity Tools --- Unable to run. Ensure Audacity is running with mod-script-pipe. Or try to restart Blender.")
     
     return TOPIPE, FROMPIPE, EOL
 
@@ -34,6 +33,8 @@ TOPIPE, FROMPIPE, EOL = return_audacity_pipe()
 
 
 def check_pipe(launch=True):
+    print("Audacity Tools --- Looking for Audacity pipe")
+
     global TOPIPE
     global FROMPIPE
     global EOL
@@ -55,6 +56,7 @@ def check_pipe(launch=True):
         return True
 
     elif launch:
+        print("Audacity Tools --- Trying to launch Audacity")
         if launch_audacity():
             time.sleep(get_addon_preferences().audacity_waiting_time)
             _to, _from, _eol = return_audacity_pipe()

--- a/pipe_utilities.py
+++ b/pipe_utilities.py
@@ -33,7 +33,7 @@ def return_audacity_pipe():
 TOPIPE, FROMPIPE, EOL = return_audacity_pipe()
 
 
-def check_pipe():
+def check_pipe(launch=True):
     global TOPIPE
     global FROMPIPE
     global EOL
@@ -54,15 +54,16 @@ def check_pipe():
         EOL = _eol
         return True
 
-    elif launch_audacity():
-        time.sleep(get_addon_preferences().audacity_waiting_time)
-        _to, _from, _eol = return_audacity_pipe()
-        if _to is not None:
-            TOPIPE = _to
-            FROMPIPE = _from
-            EOL = _eol
-            return True
-            
+    elif launch:
+        if launch_audacity():
+            time.sleep(get_addon_preferences().audacity_waiting_time)
+            _to, _from, _eol = return_audacity_pipe()
+            if _to is not None:
+                TOPIPE = _to
+                FROMPIPE = _from
+                EOL = _eol
+                return True
+
     return False
 
 

--- a/properties.py
+++ b/properties.py
@@ -23,8 +23,8 @@ class AUDACITYTOOLS_PR_properties(bpy.types.PropertyGroup) :
             ("STRIP", "Strip", ""),
             ("SEQUENCE", "Sequence", ""),
             ("RECORD", "Record", ""),
-        ),
-    )
+            ),
+        )
 
 
 ### REGISTER ---

--- a/properties.py
+++ b/properties.py
@@ -35,7 +35,11 @@ def register():
     bpy.types.Scene.audacity_tools_props = \
         bpy.props.PointerProperty(type = AUDACITYTOOLS_PR_properties, name="Audacity tools properties")
 
+    bpy.types.WindowManager.audacity_tools_pipe_available = \
+        bpy.props.BoolProperty(default = False)
+
 def unregister():
     bpy.utils.unregister_class(AUDACITYTOOLS_PR_properties)
 
     del bpy.types.Scene.audacity_tools_props
+    del bpy.types.WindowManager.audacity_tools_pipe_available

--- a/startup_handler.py
+++ b/startup_handler.py
@@ -1,13 +1,13 @@
 import bpy
 
 from bpy.app.handlers import persistent
-from .pipe_utilities import check_pipe
+from .pipe_utilities import check_set_pipe
 
 
 @persistent
 def audacity_tools_startup(scene):
     # check pipe
-    check_pipe(False)
+    check_set_pipe(False)
 
     # reset properties
     for s in bpy.data.scenes:

--- a/startup_handler.py
+++ b/startup_handler.py
@@ -1,10 +1,15 @@
 import bpy
 
 from bpy.app.handlers import persistent
+from .pipe_utilities import check_pipe
 
 
 @persistent
 def audacity_tools_startup(scene):
+    # check pipe
+    check_pipe(False)
+
+    # reset properties
     for s in bpy.data.scenes:
         props = s.audacity_tools_props
         props.send_strip = ""


### PR DESCRIPTION
Turned the pipe getter into a method to be able to reuse it.
So now operators will check for pipe before the main execution, and try to update it (if audacity has been opened since blender launched)

In the addon prefs, there is now a property to point on the audacity executable to allow the addon to automatically launch it.
A downside is to have a waiting time, between calling audacity and having it open and ready. This waiting time, if too short, can cause error. The default seems ok (5s) but it can be set by user in prefs if needed.
An improvement could be to have an operator processing this automatically, but for now, seems ok.

Here is a little demo video : 
https://youtu.be/o2HQz504-ls